### PR TITLE
Fix emitting empty file when encryption is enabled

### DIFF
--- a/lib/Controller/ConversionController.php
+++ b/lib/Controller/ConversionController.php
@@ -38,8 +38,8 @@ class ConversionController extends Controller {
 		if (file_exists($file)){
 			$cmd = $this->createCmd($file, $preset, $type, $priority, $movflags, $codec, $vbitrate, $scale);
 			exec($cmd, $output,$return);
-			// if the file is un external storage
-			if($external){
+			// if the file is in external storage, and also check if encryption is enabled
+			if($external || \OC::$server->getEncryptionManager()->isEnabled()){
 				//put the temporary file in the external storage
 				Filesystem::file_put_contents($directory . '/' . pathinfo($nameOfFile)['filename'].".".$type, file_get_contents(dirname($file) . '/' . pathinfo($file)['filename'].".".$type));
 				// check that the temporary file is not the same as the new file


### PR DESCRIPTION
When encryption is enabled, getLocalFile() will return getCachedFile(), which will gives a temporary file in /tmp folder. Once the app closes, the file will be deleted. Hence, we will get a file in Nextcloud which points to a deleted file. So, for an encrypted environment, copying back with Nextcloud's built-in function is needed. This patch fixes the bug above.