### PR TITLE
Added support for `copy` codec

### DIFF
--- a/js/conversion.js
+++ b/js/conversion.js
@@ -73,6 +73,7 @@ $(document).ready(function () {
                         + '<option value="none">Auto</option>'
                         + '<option value="x264">H264</option>'
                         + '<option value="x265">HEVC</option>'
+                        + '<option value="copy">Copy</option>'
                         + '</select>'
                         + '<p class="vc-label urldisplay" id="labelBitrate" style="display:inline-block; margin-right:5px;">'
                         + 'Target bitrate'

--- a/lib/Controller/ConversionController.php
+++ b/lib/Controller/ConversionController.php
@@ -174,6 +174,11 @@ class ConversionController extends Controller {
 			}
 		}
 		//echo $link;
+		// I put this here because the code up there seems to be chained in a string builder and I didn't want to disrupt the code too much.
+		// This is useful if you just want to change containers types, and do no work with codecs. So you can convert an MKV to MP4 almost instantly.
+		if($codec == "copy"){
+			$middleArgs = "-codec copy";
+		}
 		$cmd = " ffmpeg -y -i ".escapeshellarg($file)." ".$middleArgs." ".escapeshellarg(dirname($file) . '/' . pathinfo($file)['filename'].".".$output);
 		if ($priority != "0"){
 			$cmd = "nice -n ".escapeshellarg($priority).$cmd;


### PR DESCRIPTION
This is useful if you just want to change containers types without re-coding the video or audio stream.
So you can convert an MKV to MP4 almost instantly.

Most of my conversion needs are just container changes, so I guess this might be useful for other people too.